### PR TITLE
When TTL is set, ignore the maxAge.

### DIFF
--- a/lib/DynamoDBStore.js
+++ b/lib/DynamoDBStore.js
@@ -54,7 +54,7 @@ export default class DynamoDBStore extends Store {
     const {
       table = {},
       touchInterval = DEFAULT_TOUCH_INTERVAL,
-      ttl = DEFAULT_TTL,
+      ttl,
       keepExpired = DEFAULT_KEEP_EXPIRED_POLICY,
     } = options;
 
@@ -294,10 +294,12 @@ export default class DynamoDBStore extends Store {
    */
   getExpirationDate(sess: Object): Date {
     let expirationDate = Date.now();
-    if (sess.cookie && Number.isInteger(sess.cookie.maxAge)) {
+    if (this.ttl !== undefined) {
+      expirationDate += this.ttl;
+    } else if (sess.cookie && Number.isInteger(sess.cookie.maxAge)) {
       expirationDate += sess.cookie.maxAge;
     } else {
-      expirationDate += this.ttl;
+      expirationDate += DEFAULT_TTL;
     }
     return new Date(expirationDate);
   }

--- a/test/DynamoDBStore.test.js
+++ b/test/DynamoDBStore.test.js
@@ -17,7 +17,6 @@ const TEST_OPTIONS = {
       connectTimeout: 1000,
     },
   },
-  ttl: 10000,
   touchInterval: 0,
 };
 


### PR DESCRIPTION
This makes is possible to have long living cookies with shorter sessions (TTL).